### PR TITLE
Updated to use C++14, updated to use steady_clock instead of monotonic clock, made it clear it only does RGB-D data 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Python bindings generated using [pybind11](https://pybind11.readthedocs.io/en/st
 1. Clone the repo with `--recursive`
 2. Install `Eigen`, `Pangolin` and `OpenCV` if you havn't already.
 3. `ORB-SLAM3` requires `openssl` to be installed: `sudo apt-get install libssl-dev`
-4. Run `python setup install` or `pip install .`.
-5. Please raise an issue if you run into any.
+4. Install some pip packages: `pip install pillow pyparsing pytz six`
+5. Run `python setup install` or `pip install .`.
+6. Please raise an issue if you run into any.
 
 ## Demo
 
@@ -30,6 +31,9 @@ Please see the demo at `demo/run_rgb.py` for how to use this code. For example, 
 ```bash
 python demo/run_rgbd.py \
     --vocab_file=third_party/ORB_SLAM3/Vocabulary/ORBvoc.txt \
-    --settings_file=third_party/ORB_SLAM3/Examples/RGB-D/TUM1.yaml \
-    --dataset_path=/mnt/dataset2/TUM/rgbd_dataset_freiburg1_xyz
+    --settings_file=third_party/ORB_SLAM3/Examples/Monocular/EuRoC.yaml \
+    --dataset_path=/home/sam3/Desktop/Toms_Workspace/data/orbslam_example_data/MH01
 ```
+
+## Note
+I found that extracting third_party/ORB_SLAM3/Vocabulary/ORBvoc.txt.tar.gz was not working. I had to download the file from the ORB-SLAM3 github repo and extract it manually.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ORB-SLAM3-PYTHON
 ===
+Only currently supports RGB-D datasets.
 
 Python bindings generated using [pybind11](https://pybind11.readthedocs.io/en/stable/). We use a modified version of ORB-SLAM3 (included as a submodule) to exntend interfaces. It might not be the most up-to-date with the original ORB-SLAM3.
 
@@ -31,8 +32,8 @@ Please see the demo at `demo/run_rgb.py` for how to use this code. For example, 
 ```bash
 python demo/run_rgbd.py \
     --vocab_file=third_party/ORB_SLAM3/Vocabulary/ORBvoc.txt \
-    --settings_file=third_party/ORB_SLAM3/Examples/Monocular/EuRoC.yaml \
-    --dataset_path=/home/sam3/Desktop/Toms_Workspace/data/orbslam_example_data/MH01
+    --settings_file=third_party/ORB_SLAM3/Examples/RGB-D/TUM1.yaml \
+    --dataset_path=/mnt/SSD_4T/TUM/rgbd_dataset_freiburg1_xyz
 ```
 
 ## Note


### PR DESCRIPTION
I was having the same issue as https://github.com/xingruiyang/ORB-SLAM3-python/issues/2, made some changes so that issue no longer occurs.